### PR TITLE
exportJson: trim final newline from "replace": key

### DIFF
--- a/public/js/config.js
+++ b/public/js/config.js
@@ -128,7 +128,7 @@ function exportJson(ev) {
 
     if (key.innerText)
       data.push({
-        replace: key.innerText,
+        replace: key.innerText.replace(/\n$/, ''),
         with: value.innerText
       });
   });


### PR DESCRIPTION
Attempts to fix the error in the export function which causes it to add a literal newline to the end of each key.

(I know next to nothing about Javascript, and I don't know how to test this; but hopefully at least it will help figure out how to fix this.)